### PR TITLE
Add new `Node#toPair()` class method

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -106,6 +106,10 @@ class Node {
   isRightPartial() {
     return !this.left && this.right !== null;
   }
+
+  toPair() {
+    return [this.key, this.value];
+  }
 }
 
 module.exports = Node;

--- a/test/node.js
+++ b/test/node.js
@@ -139,3 +139,8 @@ test('isRightPartial', t => {
   node.left = left;
   t.false(node.isRightPartial());
 });
+
+test('toPair', t => {
+  const node = new Node(10, 'A');
+  t.deepEqual(node.toPair(), [10, 'A']);
+});

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -19,6 +19,7 @@ declare namespace node {
     isLeftPartial(): boolean;
     isPartial(): boolean;
     isRightPartial(): boolean;
+    toPair(): [number, T];
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#toPair()`

The method returns an ordered-pair/2-tuple, where the first element is a number corresponding to the `key` of the node, and the last one is a value, that can be of any type, corresponding to the `value` stored in the node.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.
